### PR TITLE
Let main spawn all the builds

### DIFF
--- a/fusebuild/core/action_invoker.py
+++ b/fusebuild/core/action_invoker.py
@@ -19,6 +19,7 @@ class WaitingFor(Protocol):
 class ActionInvoker(Protocol):
     def waiting_for(self, label: ActionLabel) -> AbstractContextManager[WaitingFor]: ...
 
+    def get_label(self) -> ActionLabel | None: ...
     def runtarget_args(self) -> list[str]: ...
 
 
@@ -37,6 +38,9 @@ class DummyInvoker(ActionInvoker):
                 pass
 
         return WaitingForImpl()
+
+    def get_label(self) -> ActionLabel | None:
+        return None
 
     def runtarget_args(self) -> list[str]:
         return []

--- a/fusebuild/core/actions.py
+++ b/fusebuild/core/actions.py
@@ -83,7 +83,7 @@ def write_actions() -> Any:
 
 
 def get_action(path: Path | str, name: str) -> Action:
-    path = Path(path).absolute()
+    path = Path(path).resolve()
     label = ActionLabel(path, name)
     if label in loaded_actions:
         return loaded_actions[label]

--- a/fusebuild/core/file_layout.py
+++ b/fusebuild/core/file_layout.py
@@ -122,3 +122,11 @@ def invocation_failed_file(label: ActionLabel) -> Path:
         / str(label.path).lstrip("/")
         / label.name
     )
+
+
+def socket_path() -> Path | None:
+    """Path to the unix socket used to mark a task as blocked"""
+    if not has_invocation_dir():
+        return None
+
+    return Path(os.environ[FUSEBUILD_INVOCATION_DIR]) / "fusebuild.sock"

--- a/fusebuild/core/fuse_mount.py
+++ b/fusebuild/core/fuse_mount.py
@@ -114,7 +114,7 @@ class BasicMount(Fuse):  # type: ignore
             self.access_recorder.record_dir_exists(src_dir, True)
         else:
             self.access_recorder.record_dir_exists(src_dir, False)
-            success, label = check_build_target(src_dir, self.invoker)
+            success, label = check_build_target(src_dir, self.invoker, True)
             if label is not None:
                 self.access_recorder.action_deps.add(label)
             if not success:

--- a/fusebuild/core/libfusebuild.py
+++ b/fusebuild/core/libfusebuild.py
@@ -18,6 +18,7 @@ import json
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -29,6 +30,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from enum import Enum
 from errno import *
+from io import TextIOWrapper
 from pathlib import Path
 from stat import *
 from threading import Lock, Thread
@@ -74,6 +76,7 @@ from fusebuild.core.file_layout import (
     new_access_log_file,
     output_folder_root,
     output_folder_root_str,
+    socket_path,
     status_file,
     status_lock_file,
     stderr_file,
@@ -84,7 +87,7 @@ from fusebuild.core.file_layout import (
 
 from .action_invoker import ActionInvoker, WaitingFor
 from .fuse_mount import BasicMount, unmount
-from .utils import check_pid, kill_subprocess, os_environ, run_action
+from .utils import check_pid, escape_whitespace, kill_subprocess, os_environ, run_action
 
 logger = logger_module.getLogger(__name__)
 
@@ -93,8 +96,82 @@ logger = logger_module.getLogger(__name__)
 dependencies_ok: dict[ActionLabel, bool] = {}
 
 
+def check_build_target_local(label: ActionLabel) -> bool | None:
+    if label in dependencies_ok:
+        logger.debug(f"{label} was in dependencies_ok")
+        return True
+
+    if has_invocation_dir():
+        if invocation_ok_file(label).exists():
+            logger.debug(f"{label} was present in ok dir.")
+            dependencies_ok[label] = True
+            return True
+
+        if invocation_failed_file(label).exists():
+            logger.debug(f"{label} was already marked as failed.")
+            return False
+
+    return None
+
+
+main_connection_file: None | TextIOWrapper = None
+
+
+def ask_main_to_build(label: ActionLabel, for_label: ActionLabel, hard: bool) -> bool:
+    global main_connection_file
+    if main_connection_file is None:
+        logger.info(f"{socket_path()=}")
+        if socket_path() is None:
+            return False
+        client_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client_socket.connect(str(socket_path()))
+        main_connection_file = client_socket.makefile("rw")
+
+    try:
+        message = (
+            "needs: "
+            + escape_whitespace(str(for_label))
+            + " "
+            + escape_whitespace(str(label))
+            + (" hard" if hard else "")
+        )
+        logger.info(f"Sending '{message}' to main")
+        main_connection_file.write(message + "\n")
+        main_connection_file.flush()
+        answer = main_connection_file.readline()
+        logger.debug(f"Got {answer} from main")
+    except Exception as ex:
+        logger.error(f"Got exception when sending to main: {ex}")
+        main_connection_file = None
+        # Return True makes us try again
+    return True
+
+
+def check_label_is_build(
+    label: ActionLabel, for_label: ActionLabel, hard: bool
+) -> bool | None:
+    while True:
+        known_result = check_build_target_local(label)
+        logger.debug(f"Is {label} build? {known_result}")
+        match known_result:
+            case True:
+                return True
+            case False:
+                return False
+            case None:
+                if not ask_main_to_build(label, for_label, hard):
+                    # If we can't for some reason ask main to build it continue below
+                    logger.warning(f"Can't ask main about {label}")
+                    break
+            case _:
+                logger.error("Got {known_result=}")
+                assert False
+
+    return None
+
+
 def check_build_target(
-    src_dir: Path, invoker: ActionInvoker
+    src_dir: Path, invoker: ActionInvoker, hard: bool
 ) -> tuple[bool, ActionLabel | None]:
     src_dir = src_dir.absolute()
     while True:
@@ -110,20 +187,17 @@ def check_build_target(
             return True, None
 
     label = ActionLabel(src_dir.resolve(), target)
-
-    if label in dependencies_ok:
-        logger.debug(f"{label} was in dependencies_ok")
-        return True, label
-
-    if has_invocation_dir():
-        if invocation_ok_file(label).exists():
-            logger.debug(f"{label} was present in ok dir.")
-            dependencies_ok[label] = True
+    invoker_label = invoker.get_label()
+    assert invoker_label is not None
+    match check_label_is_build(label, invoker_label, hard):
+        case True:
             return True, label
-
-        if invocation_failed_file(label).exists():
-            logger.debug(f"{label} was already marked as failed.")
+        case False:
             return False, label
+        case None:
+            pass
+
+    logger.warning(f"{label} is not build - figuring it out here.")
 
     action = get_action(src_dir, target, invoker)
     match action:
@@ -175,6 +249,9 @@ class ExecuterBase(ActionInvoker):
     @property
     def name(self) -> str:
         return self.label.name
+
+    def get_label(self) -> ActionLabel:
+        return self.label
 
     def runtarget_args(self) -> list[str]:
         return [str(self.label.path), self.label.name]
@@ -281,6 +358,7 @@ class BasicExecuter(ExecuterBase):
                 else invocation_failed_file(self.label)
             )
             done_file.parent.mkdir(parents=True, exist_ok=True)
+            logger.debug(f"Writing donefile {done_file}")
             with done_file.open("w") as f:
                 f.write(f"{retcode}\n")
 
@@ -626,7 +704,11 @@ class BasicExecuter(ExecuterBase):
                 print(f"{self.directory} / {self.name}: Action changed")
                 matches = False
             else:
-                matches = check_accesses(self.label, check_build_target, self)
+                matches = check_accesses(
+                    self.label,
+                    lambda path, invoker: check_build_target(path, invoker, False),
+                    self,
+                )
 
         if action_setup_record_old is None:
             return Ok(True)
@@ -785,6 +867,7 @@ def load_actions(path: Path) -> dict[ActionLabel, Action]:
     ).absolute()
     actions = {}
     for action_file in actions_path.glob("*.json"):
+        logger.debug(f"Found actionfile {action_file}")
         name = action_file.name.removesuffix(".json")
         label = ActionLabel(path, name)
         action = load_action_file(label, action_file)
@@ -796,14 +879,28 @@ def load_actions(path: Path) -> dict[ActionLabel, Action]:
 
 
 def check_build_file(
-    buildfile: Path, invoker: ActionInvoker, reason: str
+    buildfile: Path, invoker: ActionInvoker, looking_for: ActionLabel
 ) -> Result[dict[ActionLabel, Action], int | None]:
     logger.debug(f"check_build_file({buildfile})")
     buildfile = buildfile.absolute()
+
     if not buildfile.exists():
         return Err(None)
+
+    label = ActionLabel(buildfile.parent, buildfile.name)
+    for_label = invoker.get_label()
+    if for_label is None:
+        for_label = looking_for
+    match check_label_is_build(label, for_label, False):
+        case True:
+            return Ok(load_actions(buildfile.parent))
+        case False:
+            return Err(1)
+        case None:
+            pass
+
     executer = LoadBuildFileExecuter(buildfile)
-    ret = executer.run_if_needed(invoker, reason)
+    ret = executer.run_if_needed(invoker, str(looking_for))
     logger.debug(f"run_if_needed for {buildfile}: {ret}")
     if ret is not None:
         executer.release_lock()
@@ -833,7 +930,7 @@ def get_action(
         # SBUILD file load and actions are up-to-date, but no such action
         return None
 
-    res = check_build_file(path / "FUSEBUILD.py", invoker, str(label))
+    res = check_build_file(path / "FUSEBUILD.py", invoker, label)
     match res:
         case Err(ret):
             logger.warning(f"Failed to load {path / 'FUSEBUILD.py'}: Returned {ret}")
@@ -848,23 +945,35 @@ def get_action(
     return loaded_actions[label]
 
 
+noaction = Action(cmd=[], category="nonexistring")
+
+
+class NonExistingActionExecuter(BasicExecuter):
+    def __init__(self, label: ActionLabel):
+        super(NonExistingActionExecuter, self).__init__(label, noaction)
+
+    def run_if_needed(self, invoker: ActionInvoker, reason: str) -> int:
+        self.mark_as_done(0)
+        return 0
+
+
 def get_action_executer(
     p: Path, name: str, invoker: ActionInvoker
-) -> BasicExecuter | None:
+) -> BasicExecuter | int:
     if name == "FUSEBUILD.py":
         return LoadBuildFileExecuter(p / name)
 
+    p = p.resolve()
+    if p.is_file():
+        p = p.parent
     action = get_action(p, name, invoker)
     logger.debug(f"get_action_executer({p}, {name}) = {action}")
     match action:
         case None:
-            return None
+            return NonExistingActionExecuter(ActionLabel(p, name))
         case int(res):
-            return None
+            return res
         case _:
-            p = p.resolve()
-            if p.is_file():
-                p = p.parent
             return ActionExecuter(ActionLabel(p, name), action)
 
 

--- a/fusebuild/core/libfusebuild.py
+++ b/fusebuild/core/libfusebuild.py
@@ -792,7 +792,7 @@ def check_deadlock(label: ActionLabel, reason: str) -> bool:
 
 class LoadBuildFileExecuter(BasicExecuter):
     def __init__(self, buildfile: Path) -> None:
-        buildfile = buildfile.absolute()
+        buildfile = buildfile.resolve()
         cmd = [
             "python",
             "-m",

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -16,7 +16,7 @@ from enum import Enum
 from multiprocessing import cpu_count
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Iterable, Protocol
+from typing import Any, Awaitable, Callable, Iterable, Protocol
 
 import filelock
 import psutil
@@ -28,6 +28,7 @@ from .action_invoker import ActionInvoker, DummyInvoker
 from .file_layout import (
     FUSEBUILD_INVOCATION_DIR,
     action_dir,
+    socket_path,
     status_lock_file,
     stderr_file,
     stdout_file,
@@ -42,7 +43,7 @@ from .libfusebuild import (
     load_actions,
 )
 from .logger import FUSEBUILD_LOG_LEVEL, getLogger
-from .utils import run_action_cmd_env
+from .utils import run_action_cmd_env, unescape_whitespace
 
 logger = getLogger(__name__)
 
@@ -121,6 +122,7 @@ class BuildActionStatus(Enum):
 # RUNABLE -> RUNNING when start runnning
 # RUNNING -> BLOCKED when unknown deps are found while running
 # BLOCKED -> BLOCKED_RUNABLE when blocker have finished
+# BLOCKED_RUNABLE -> RUNNING when it is scheduled to continue
 # RUNNING -> SUCCESSFULL when done with return code 0
 # RUNNING -> FAILED when done with return code non-zero 0
 
@@ -147,12 +149,14 @@ class BuildAction:
     needed: bool
     status: BuildActionStatus = BuildActionStatus.WAITING
     deps: set[ActionLabel] = field(default_factory=set)
+    hard_deps: set[ActionLabel] = field(default_factory=set)
     dependers: set[ActionLabel] = field(default_factory=set)
-    done_actions: set[Callable[[], None]] = field(default_factory=set)
+    done_actions: set[Callable[[], Awaitable[None]]] = field(default_factory=set)
+    connections: set[asyncio.StreamWriter] = field(default_factory=set)
 
 
 class ActionExecuter(Protocol):
-    def schedule_action(self, action: BuildAction) -> None:
+    async def schedule_action(self, action: BuildAction) -> None:
         """Execute action if it matches category"""
         ...
 
@@ -181,19 +185,25 @@ class ActionExecuterImpl(ActionExecuter):
         self.max_running = max_running
         self.invoker = DummyInvoker()
         self.invocation_dir = invocation_dir
-        self.open_connections: list[asyncio.StreamWriter] = []
+        self.open_connections: set[asyncio.StreamWriter] = set([])
         self.connection_reader_tasks: set[asyncio.Task[Any]] = set()
+        self.pending: list[BuildAction] = []
+        self.wakeup: asyncio.Queue[None] = asyncio.Queue()
 
     def _update_dependers(self, action: BuildAction) -> None:
         for d in action.deps:
             self.actions[d].dependers.add(action.label)
 
-    def _waiting_or_runable(self, action: BuildAction) -> None:
+    async def _waiting_or_runable(self, action: BuildAction) -> None:
         if waiting_status(action.status) or runable_status(action.status):
             undone_dep = False
             for d in action.deps:
+                logger.debug(
+                    f"{action.label} depends on {d} with status {self.actions[d].status}"
+                )
                 if not finished_status(self.actions[d].status):
-                    undone_deps = True
+                    logger.debug(f"{action.label} must wait for {d} to finish.")
+                    undone_dep = True
                     break
 
             match action.status:
@@ -216,14 +226,19 @@ class ActionExecuterImpl(ActionExecuter):
                         action.status = BuildActionStatus.RUNABLE
                         self.runable.add(action.label)
                         self.waiting.discard(action.label)
-
                 case _:
                     assert False
+
+        await self.wakeup.put(None)
+        logger.info(f"{action.label} is now in status {action.status}")
 
     def running(self) -> int:
         return len(self.started) - len(self.blocked) - len(self.blocked_runable)
 
-    def schedule_action(self, action: BuildAction) -> None:
+    def schedule_action_nonasync(self, action: BuildAction) -> None:
+        self.pending.append(action)
+
+    async def schedule_action(self, action: BuildAction) -> None:
         self.need_resort = True
         logger.debug(f"Scheduling {action.label}")
         if action.label in self.actions:
@@ -233,7 +248,7 @@ class ActionExecuterImpl(ActionExecuter):
             old_action.needed = old_action.needed or action.needed
             # old_action dependenders already done, only new ones
             self._update_dependers(action)
-            self._waiting_or_runable(old_action)
+            await self._waiting_or_runable(old_action)
         else:
             self.actions[action.label] = action
             self.waiting.add(action.label)
@@ -241,17 +256,19 @@ class ActionExecuterImpl(ActionExecuter):
                 logger.debug(f"Adding dependency {d} for {action.label}")
                 action.deps.add(d)
                 if d not in self.actions:
-                    self.schedule_action(BuildAction(d, needed=False))
+                    await self.schedule_action(BuildAction(d, needed=False))
             if action.label.name != "FUSEBUILD.py":
                 bf_label = ActionLabel(action.label.path, "FUSEBUILD.py")
                 logger.debug(f"Adding {bf_label} for {action.label}")
 
                 action.deps.add(bf_label)
+                action.hard_deps.add(bf_label)
                 if bf_label not in self.actions:
-                    self.schedule_action(BuildAction(bf_label, needed=True))
+                    await self.schedule_action(BuildAction(bf_label, needed=True))
+                self._update_dependers(action)
 
             self._update_dependers(action)
-            self._waiting_or_runable(action)
+            await self._waiting_or_runable(action)
 
     async def start_running(self, action: BuildAction) -> None:
         logger.debug(f"Starting {action.label}")
@@ -268,23 +285,44 @@ class ActionExecuterImpl(ActionExecuter):
         task = asyncio.create_task(proc.wait())
         self.started[task] = (proc, action)
 
-    def action_done(self, task: asyncio.Task[Any]) -> None:
+    async def action_done(self, task: asyncio.Task[Any]) -> None:
         assert task in self.started
+
         process, action = self.started.pop(task)
         logger.debug(f"{action.label}: {process.returncode}")
         if process.returncode == 0:
             action.status = BuildActionStatus.SUCCESSFULL
             print(f"{action.label} ... Ok")
             for done_cb in action.done_actions:
-                done_cb()
+                await done_cb()
         else:
             print(f"{action.label} ... Failed")
             action.status = BuildActionStatus.FAILED
             if action.needed:
                 self.failures.append(action)
 
+        logger.info(f"{action.label} is now in status {action.status}")
         for d in action.dependers:
-            self._waiting_or_runable(self.actions[d])
+            await self._waiting_or_runable(self.actions[d])
+
+    def _check_for_deadlock_inner(
+        self, at: ActionLabel, seen: list[ActionLabel]
+    ) -> bool:
+        if at in seen:
+            print(f"Deadlock: {at} ->", file=sys.stderr)
+            for p in seen[::-1]:
+                print(f"   {p} ->", file=sys.stderr)
+            return True
+
+        seen_now = seen + [at]
+        for hd in self.actions[at].hard_deps:
+            if self._check_for_deadlock_inner(hd, seen_now):
+                return True
+
+        return False
+
+    def _check_for_deadlock(self, start: ActionLabel) -> bool:
+        return self._check_for_deadlock_inner(start, [])
 
     async def _read_from_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -293,36 +331,78 @@ class ActionExecuterImpl(ActionExecuter):
         logger.info(f"Start reading from {peername}")
         try:
             while not reader.at_eof():
-                line = await reader.readline()
-                if not line:
+                logger.debug(f"Before reading from {peername}")
+                line_bytes = await reader.readline()
+                logger.debug(f"After reading from {peername}: {line_bytes=}")
+
+                if not line_bytes:
                     break
-                logger.info(f"Received from {peername}: {line.decode().strip()}")
+                line: str = line_bytes.decode().rstrip()
+                logger.debug(f"Received from {peername}: {line}")
+                split = line.split(" ")
+                if split[0] == "needs:":
+                    invoker_label = label_from_line(unescape_whitespace(split[1]))
+                    to_build = label_from_line(unescape_whitespace(split[2]))
+                    hard = len(split) > 3 and split[3] == "hard"
+                    invoking_action = self.actions[invoker_label]
+                    await self.schedule_action(
+                        BuildAction(to_build, invoking_action.needed)
+                    )
+                    invoking_action.deps.add(to_build)
+                    self._update_dependers(invoking_action)
+
+                    invoking_action.connections.add(writer)
+                    invoking_action.status = BuildActionStatus.BLOCKED
+                    self.blocked.add(invoking_action.label)
+
+                    if hard:
+                        invoking_action.hard_deps.add(to_build)
+                        if self._check_for_deadlock(invoking_action.label):
+                            invoking_action.status = BuildActionStatus.FAILED
+                            self.failures.append(invoking_action)
+
+                    await self._waiting_or_runable(invoking_action)
+                else:
+                    logger.error("Got unknwown command on internal socket:" + line)
         except asyncio.CancelledError:
             logger.info(f"Reader task for {peername} cancelled.")
-            raise
-        except Exception as e:
-            logger.error(f"Error reading from {peername}: {e}")
+        except ConnectionResetError:
+            logger.info(f"Reader task for {peername} closed.")
+        except BrokenPipeError:
+            logger.info(f"Reader task for {peername} closed (broken pipe).")
+        except Exception as ex:
+            logger.error("An error occurred", exc_info=True)
+            logger.error(f"Error reading from {peername}: {type(ex)}")
         finally:
             logger.info(f"Closing connection from {peername}")
-            if writer in self.open_connections:
-                self.open_connections.remove(writer)
+            self.open_connections.discard(writer)
             writer.close()
             await writer.wait_closed()
+
+    def remove_connection_reader_task(self, task: asyncio.Task[Any]) -> None:
+        logger.debug("Removing connection")
+        self.connection_reader_tasks.discard(task)
 
     async def handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         peername = writer.get_extra_info("peername")
         logger.info(f"Received connection from {peername}")
-        self.open_connections.append(writer)
+        self.open_connections.add(writer)
 
         task = asyncio.create_task(self._read_from_connection(reader, writer))
         self.connection_reader_tasks.add(task)
-        task.add_done_callback(self.connection_reader_tasks.discard)
+        logger.debug(
+            f"Now there are {len(self.connection_reader_tasks)}/{len(self.open_connections)} connections"
+        )
+        task.add_done_callback(self.remove_connection_reader_task)
 
     async def unblock(self, action: BuildAction) -> None:
-        # TODO
-        assert False
+        assert len(action.connections) > 0
+        for c in action.connections:
+            logger.debug(f"Sending 'try again' to {action.label}")
+            c.write(b"try again\n")
+        self.blocked_runable.remove(action.label)
 
     def pick_waiter(self) -> BuildAction:
         return self.pick_one(self.waiting)
@@ -347,12 +427,15 @@ class ActionExecuterImpl(ActionExecuter):
         return best
 
     async def run(self) -> int:
-        socket_path = self.invocation_dir / "fusebuild.sock"
+        s_path = socket_path()
+        assert s_path is not None
         server = await asyncio.start_unix_server(
-            self.handle_connection, path=str(socket_path)
+            self.handle_connection, path=str(s_path)
         )
         logger.info(f"Listening on unix socket {socket_path}")
-
+        for action in self.pending:
+            await self.schedule_action(action)
+        self.pending = []
         try:
             while True:
                 if len(self.failures) > 0:
@@ -360,6 +443,9 @@ class ActionExecuterImpl(ActionExecuter):
                     print_failure(failure.label, set([]))
                     return 1
 
+                logger.debug(
+                    f"{len(self.waiting)=} {len(self.runable)=} {len(self.started)=} {len(self.blocked)=}  {len(self.blocked_runable)=}"
+                )
                 while self.running() < self.max_running:
                     if len(self.blocked_runable) > 0:
                         await self.unblock(self.pick_one(self.blocked_runable))
@@ -375,14 +461,26 @@ class ActionExecuterImpl(ActionExecuter):
                 ):
                     # We are stuck - cyclic dependencies
                     # We can try to force one to start
-                    await self.start_running(self.pick_waiter())
+                    to_run = self.pick_waiter()
+                    logger.warning(f"Might be in deadlock. Try running {to_run.label}")
+                    await self.start_running(to_run)
 
-                if self.running() == 0 and len(self.waiting) == 0:
+                if (
+                    self.running() == 0
+                    and len(self.waiting) == 0
+                    and len(self.runable) == 0
+                    and len(self.blocked) == 0
+                    and len(self.blocked_runable) == 0
+                ):
                     return 0
 
-                logger.debug(f"Waiting for one of {len(self.started)} actions.")
+                logger.debug(
+                    f"Waiting for one of {len(self.started)} started actions and {len(self.connection_reader_tasks)}/{len(self.open_connections)} connections"
+                )
+                wakeup_task = asyncio.create_task(self.wakeup.get())
+
                 done, pending = await asyncio.wait(
-                    [t for t in self.started.keys()],
+                    [t for t in self.started.keys()] + [wakeup_task],
                     timeout=10,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
@@ -391,12 +489,16 @@ class ActionExecuterImpl(ActionExecuter):
                     continue
 
                 for d in done:
-                    self.action_done(d)
+                    logger.debug(f"Done d={d}")
+                    if d == wakeup_task:
+                        continue
+                    await self.action_done(d)
         finally:
             logger.info("Closing unix socket")
             server.close()
             await server.wait_closed()
-            socket_path.unlink(missing_ok=True)
+
+            s_path.unlink(missing_ok=True)
 
             if self.connection_reader_tasks:
                 logger.info(
@@ -420,12 +522,12 @@ class ScheduleAll:
     bf_label: ActionLabel
     categories: frozenset[str]
 
-    def __call__(self) -> None:
+    async def __call__(self) -> None:
         actions = load_actions(self.bf_label.path)
         print(f"Loading all actions {self.bf_label}")
         for label, action in actions.items():
             if action.category in self.categories:
-                self.executer.schedule_action(BuildAction(label, needed=True))
+                await self.executer.schedule_action(BuildAction(label, needed=True))
 
 
 def main_inner(args: list[str]) -> int:
@@ -457,6 +559,7 @@ def main_inner(args: list[str]) -> int:
     executer = ActionExecuterImpl(
         max_running=max_running, invocation_dir=invocation_dir
     )
+
     for ti in arg.target:
         t: Path = ti.absolute()
         logger.debug(f"Processing {ti} at {os.getcwd()=}: {t=}")
@@ -472,7 +575,7 @@ def main_inner(args: list[str]) -> int:
                     needed=True,
                     done_actions={ScheduleAll(executer, bf_label, categories)},
                 )
-                executer.schedule_action(action)
+                executer.schedule_action_nonasync(action)
 
         else:
             while True:
@@ -485,7 +588,7 @@ def main_inner(args: list[str]) -> int:
                 logger.debug(f"{t=} {name=}")
                 build_file = t / "FUSEBUILD.py"
                 if build_file.exists():
-                    executer.schedule_action(
+                    executer.schedule_action_nonasync(
                         BuildAction(ActionLabel(t, name), needed=True)
                     )
                     break

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -181,6 +181,7 @@ class ActionExecuterImpl(ActionExecuter):
         self.blocked_runable = set([])
         self.need_resort = False
         self.failures = []
+        self.deadlock_detected = False
         self.max_running = max_running
         self.invoker = DummyInvoker()
         self.invocation_dir = invocation_dir
@@ -358,6 +359,7 @@ class ActionExecuterImpl(ActionExecuter):
                         invoking_action.hard_deps.add(to_build)
                         if self._check_for_deadlock(invoking_action.label):
                             invoking_action.status = BuildActionStatus.FAILED
+                            self.deadlock_detected = True
                             self.failures.append(invoking_action)
 
                     await self._waiting_or_runable(invoking_action)
@@ -447,7 +449,10 @@ class ActionExecuterImpl(ActionExecuter):
                 if len(self.failures) > 0:
                     failure = self.failures[0]
                     print_failure(failure.label, set([]))
-                    return 1
+                    if self.deadlock_detected:
+                        return 4
+                    else:
+                        return 3
                 now = time.monotonic()
                 if now > next_print:
                     next_print += 1

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -407,6 +407,7 @@ class ActionExecuterImpl(ActionExecuter):
             logger.debug(f"Sending 'try again' to {action.label}")
             c.write(b"try again\n")
         self.blocked_runable.remove(action.label)
+        self.status = BuildActionStatus.RUNNING
 
     def pick_waiter(self) -> BuildAction:
         return self.pick_one(self.waiting)

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -33,7 +33,6 @@ from .file_layout import (
     stdout_file,
     subbuild_failed_file,
 )
-from .graph import sort_graph
 from .libfusebuild import (
     BasicExecuter,
     ExecuterBase,
@@ -108,18 +107,47 @@ def print_failure(label: ActionLabel, seen: set[ActionLabel]) -> None:
 
 
 class BuildActionStatus(Enum):
-    IN_QUEUE = 0
-    RUNNING = 1
-    SUCCESSFULL = 2
-    FAILED = 3
+    WAITING = 0
+    RUNABLE = 1
+    RUNNING = 2
+    BLOCKED = 3
+    BLOCKED_RUNABLE = 4
+    SUCCESSFULL = 5
+    FAILED = 6
+
+
+# Possible transitions:
+# WAITING -> RUNABLE when all deps are done
+# RUNABLE -> RUNNING when start runnning
+# RUNNING -> BLOCKED when unknown deps are found while running
+# BLOCKED -> BLOCKED_RUNABLE when blocker have finished
+# RUNNING -> SUCCESSFULL when done with return code 0
+# RUNNING -> FAILED when done with return code non-zero 0
+
+
+def waiting_status(s: BuildActionStatus) -> bool:
+    return s == BuildActionStatus.WAITING or s == BuildActionStatus.BLOCKED
+
+
+def have_not_started(s: BuildActionStatus) -> bool:
+    return s == BuildActionStatus.WAITING or s == BuildActionStatus.RUNABLE
+
+
+def runable_status(s: BuildActionStatus) -> bool:
+    return s == BuildActionStatus.RUNABLE or s == BuildActionStatus.BLOCKED_RUNABLE
+
+
+def finished_status(s: BuildActionStatus) -> bool:
+    return s == BuildActionStatus.SUCCESSFULL or s == BuildActionStatus.FAILED
 
 
 @dataclass
 class BuildAction:
     label: ActionLabel
     needed: bool
-    status: BuildActionStatus = BuildActionStatus.IN_QUEUE
+    status: BuildActionStatus = BuildActionStatus.WAITING
     deps: set[ActionLabel] = field(default_factory=set)
+    dependers: set[ActionLabel] = field(default_factory=set)
     done_actions: set[Callable[[], None]] = field(default_factory=set)
 
 
@@ -131,9 +159,11 @@ class ActionExecuter(Protocol):
 
 class ActionExecuterImpl(ActionExecuter):
     actions: dict[ActionLabel, BuildAction]
-    running: dict[asyncio.Task[Any], tuple[asyncio.subprocess.Process, BuildAction]]
-    waiting: list[BuildAction]
-    need_resort: bool
+    waiting: set[ActionLabel]
+    runable: set[ActionLabel]
+    started: dict[asyncio.Task[Any], tuple[asyncio.subprocess.Process, BuildAction]]
+    blocked: set[ActionLabel]
+    blocked_runable: set[ActionLabel]
     failures: list[BuildAction]
     max_running: int
     invoker: ActionInvoker
@@ -141,8 +171,11 @@ class ActionExecuterImpl(ActionExecuter):
 
     def __init__(self, max_running: int, invocation_dir: Path) -> None:
         self.actions = {}
-        self.running = {}
-        self.waiting = []
+        self.waiting = set([])
+        self.runable = set([])
+        self.started = {}
+        self.blocked = set([])
+        self.blocked_runable = set([])
         self.need_resort = False
         self.failures = []
         self.max_running = max_running
@@ -150,6 +183,45 @@ class ActionExecuterImpl(ActionExecuter):
         self.invocation_dir = invocation_dir
         self.open_connections: list[asyncio.StreamWriter] = []
         self.connection_reader_tasks: set[asyncio.Task[Any]] = set()
+
+    def _update_dependers(self, action: BuildAction) -> None:
+        for d in action.deps:
+            self.actions[d].dependers.add(action.label)
+
+    def _waiting_or_runable(self, action: BuildAction) -> None:
+        if waiting_status(action.status) or runable_status(action.status):
+            undone_dep = False
+            for d in action.deps:
+                if not finished_status(self.actions[d].status):
+                    undone_deps = True
+                    break
+
+            match action.status:
+                case BuildActionStatus.BLOCKED | BuildActionStatus.BLOCKED_RUNABLE:
+                    if undone_dep:
+                        action.status = BuildActionStatus.BLOCKED
+                        self.blocked.add(action.label)
+                        self.blocked_runable.discard(action.label)
+                    else:
+                        action.status = BuildActionStatus.BLOCKED_RUNABLE
+                        self.blocked_runable.add(action.label)
+                        self.blocked.discard(action.label)
+
+                case BuildActionStatus.WAITING | BuildActionStatus.RUNABLE:
+                    if undone_dep:
+                        action.status = BuildActionStatus.WAITING
+                        self.waiting.add(action.label)
+                        self.runable.discard(action.label)
+                    else:
+                        action.status = BuildActionStatus.RUNABLE
+                        self.runable.add(action.label)
+                        self.waiting.discard(action.label)
+
+                case _:
+                    assert False
+
+    def running(self) -> int:
+        return len(self.started) - len(self.blocked) - len(self.blocked_runable)
 
     def schedule_action(self, action: BuildAction) -> None:
         self.need_resort = True
@@ -159,9 +231,12 @@ class ActionExecuterImpl(ActionExecuter):
             old_action.deps.update(action.deps)
             old_action.done_actions.update(action.done_actions)
             old_action.needed = old_action.needed or action.needed
+            # old_action dependenders already done, only new ones
+            self._update_dependers(action)
+            self._waiting_or_runable(old_action)
         else:
             self.actions[action.label] = action
-            self.waiting.append(action)
+            self.waiting.add(action.label)
             for d in load_action_deps(action.label):
                 logger.debug(f"Adding dependency {d} for {action.label}")
                 action.deps.add(d)
@@ -175,48 +250,15 @@ class ActionExecuterImpl(ActionExecuter):
                 if bf_label not in self.actions:
                     self.schedule_action(BuildAction(bf_label, needed=True))
 
-    def sort_waiting(self) -> None:
-        graph: dict[ActionLabel, list[ActionLabel]] = {}
-
-        def members() -> Iterable[BuildAction]:
-            for a in self.waiting:
-                assert a.status == BuildActionStatus.IN_QUEUE
-                yield a
-            for ta in self.running.values():
-                assert ta[1].status == BuildActionStatus.RUNNING
-                yield ta[1]
-
-        for a in members():
-            graph[a.label] = [
-                d
-                for d in a.deps
-                if self.actions[d].status
-                in [BuildActionStatus.IN_QUEUE, BuildActionStatus.RUNNING]
-            ]
-        assert len(graph) == len(self.waiting) + len(self.running)
-        sorted_actions = sort_graph(graph)
-        assert len(sorted_actions) == len(graph)
-        waiting_new = [
-            self.actions[al]
-            for al in sorted_actions
-            if self.actions[al].status == BuildActionStatus.IN_QUEUE
-        ]
-        waiting_new_labels = set([a.label for a in waiting_new])
-        waiting_old_labels = set([a.label for a in self.waiting])
-        if waiting_new_labels != waiting_old_labels:
-            logger.error(
-                f"Missing in new labels: {waiting_old_labels - waiting_new_labels}"
-            )
-            logger.error(
-                f"New in new labels: {waiting_new_labels - waiting_old_labels}"
-            )
-            assert False
-        self.waiting = waiting_new
+            self._update_dependers(action)
+            self._waiting_or_runable(action)
 
     async def start_running(self, action: BuildAction) -> None:
         logger.debug(f"Starting {action.label}")
         print(f"{action.label}..")
-        assert action.status == BuildActionStatus.IN_QUEUE
+        assert have_not_started(action.status)
+        self.waiting.discard(action.label)
+        self.runable.discard(action.label)
         action.status = BuildActionStatus.RUNNING
         cmd, env = run_action_cmd_env(
             action.label.path, action.label.name, self.invoker
@@ -224,12 +266,11 @@ class ActionExecuterImpl(ActionExecuter):
         proc = await asyncio.create_subprocess_exec(*cmd, env=env)
         logger.debug(f"Running {cmd} with env {env} in {proc.pid=}")
         task = asyncio.create_task(proc.wait())
-        self.running[task] = (proc, action)
-        action.status = BuildActionStatus.RUNNING
+        self.started[task] = (proc, action)
 
     def action_done(self, task: asyncio.Task[Any]) -> None:
-        assert task in self.running
-        process, action = self.running.pop(task)
+        assert task in self.started
+        process, action = self.started.pop(task)
         logger.debug(f"{action.label}: {process.returncode}")
         if process.returncode == 0:
             action.status = BuildActionStatus.SUCCESSFULL
@@ -241,6 +282,9 @@ class ActionExecuterImpl(ActionExecuter):
             action.status = BuildActionStatus.FAILED
             if action.needed:
                 self.failures.append(action)
+
+        for d in action.dependers:
+            self._waiting_or_runable(self.actions[d])
 
     async def _read_from_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -276,6 +320,32 @@ class ActionExecuterImpl(ActionExecuter):
         self.connection_reader_tasks.add(task)
         task.add_done_callback(self.connection_reader_tasks.discard)
 
+    async def unblock(self, action: BuildAction) -> None:
+        # TODO
+        assert False
+
+    def pick_waiter(self) -> BuildAction:
+        return self.pick_one(self.waiting)
+
+    def pick_one(self, runables: set[ActionLabel]) -> BuildAction:
+        best = None
+        best_count = -1
+        for label in runables:
+            action = self.actions[label]
+            c = len(
+                [
+                    l
+                    for l in action.dependers
+                    if not finished_status(self.actions[l].status)
+                ]
+            )
+            if c > best_count:
+                best_count = c
+                best = action
+
+        assert best is not None
+        return best
+
     async def run(self) -> int:
         socket_path = self.invocation_dir / "fusebuild.sock"
         server = await asyncio.start_unix_server(
@@ -290,21 +360,29 @@ class ActionExecuterImpl(ActionExecuter):
                     print_failure(failure.label, set([]))
                     return 1
 
-                pre_sort = len(self.waiting)
-                if self.need_resort:
-                    self.sort_waiting()
-                assert pre_sort == len(self.waiting)
+                while self.running() < self.max_running:
+                    if len(self.blocked_runable) > 0:
+                        await self.unblock(self.pick_one(self.blocked_runable))
+                    elif len(self.runable) > 0:
+                        await self.start_running(self.pick_one(self.runable))
+                    else:
+                        break
 
-                while len(self.waiting) > 0 and len(self.running) < self.max_running:
-                    await self.start_running(self.waiting[0])
-                    self.waiting = self.waiting[1:]
+                if (
+                    self.running() == 0
+                    and len(self.runable) == 0
+                    and len(self.waiting) > 0
+                ):
+                    # We are stuck - cyclic dependencies
+                    # We can try to force one to start
+                    await self.start_running(self.pick_waiter())
 
-                if len(self.running) == 0 and len(self.waiting) == 0:
+                if self.running() == 0 and len(self.waiting) == 0:
                     return 0
 
-                logger.debug(f"Waiting for one of {len(self.running)} actions.")
+                logger.debug(f"Waiting for one of {len(self.started)} actions.")
                 done, pending = await asyncio.wait(
-                    [t for t in self.running.keys()],
+                    [t for t in self.started.keys()],
                     timeout=10,
                     return_when=asyncio.FIRST_COMPLETED,
                 )

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -137,8 +137,9 @@ class ActionExecuterImpl(ActionExecuter):
     failures: list[BuildAction]
     max_running: int
     invoker: ActionInvoker
+    invocation_dir: Path
 
-    def __init__(self, max_running: int) -> None:
+    def __init__(self, max_running: int, invocation_dir: Path) -> None:
         self.actions = {}
         self.running = {}
         self.waiting = []
@@ -146,6 +147,7 @@ class ActionExecuterImpl(ActionExecuter):
         self.failures = []
         self.max_running = max_running
         self.invoker = DummyInvoker()
+        self.invocation_dir = invocation_dir
 
     def schedule_action(self, action: BuildAction) -> None:
         self.need_resort = True
@@ -238,37 +240,58 @@ class ActionExecuterImpl(ActionExecuter):
             if action.needed:
                 self.failures.append(action)
 
+    async def handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        # For now, just log and close the connection
+        peername = writer.get_extra_info("peername")
+        logger.info(f"Received connection from {peername}")
+        writer.close()
+        await writer.wait_closed()
+
     async def run(self) -> int:
-        while True:
-            if len(self.failures) > 0:
-                failure = self.failures[0]
-                print_failure(failure.label, set([]))
-                return 1
+        socket_path = self.invocation_dir / "fusebuild.sock"
+        server = await asyncio.start_unix_server(
+            self.handle_connection, path=str(socket_path)
+        )
+        logger.info(f"Listening on unix socket {socket_path}")
 
-            pre_sort = len(self.waiting)
-            if self.need_resort:
-                self.sort_waiting()
-            assert pre_sort == len(self.waiting)
+        try:
+            while True:
+                if len(self.failures) > 0:
+                    failure = self.failures[0]
+                    print_failure(failure.label, set([]))
+                    return 1
 
-            while len(self.waiting) > 0 and len(self.running) < self.max_running:
-                await self.start_running(self.waiting[0])
-                self.waiting = self.waiting[1:]
+                pre_sort = len(self.waiting)
+                if self.need_resort:
+                    self.sort_waiting()
+                assert pre_sort == len(self.waiting)
 
-            if len(self.running) == 0 and len(self.waiting) == 0:
-                return 0
+                while len(self.waiting) > 0 and len(self.running) < self.max_running:
+                    await self.start_running(self.waiting[0])
+                    self.waiting = self.waiting[1:]
 
-            logger.debug(f"Waiting for one of {len(self.running)} actions.")
-            done, pending = await asyncio.wait(
-                [t for t in self.running.keys()],
-                timeout=10,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if len(done) == 0:
-                logger.debug("timeout")
-                continue
+                if len(self.running) == 0 and len(self.waiting) == 0:
+                    return 0
 
-            for d in done:
-                self.action_done(d)
+                logger.debug(f"Waiting for one of {len(self.running)} actions.")
+                done, pending = await asyncio.wait(
+                    [t for t in self.running.keys()],
+                    timeout=10,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if len(done) == 0:
+                    logger.debug("timeout")
+                    continue
+
+                for d in done:
+                    self.action_done(d)
+        finally:
+            logger.info("Closing unix socket")
+            server.close()
+            await server.wait_closed()
+            socket_path.unlink(missing_ok=True)
 
 
 @dataclass(frozen=True)
@@ -302,7 +325,8 @@ def main_inner(args: list[str]) -> int:
         logger.info(f"{logger.name} {log_level=}")
     logger.info(f"{arg.verbose=} {logging.getLevelName(log_level)}")
 
-    logger.info(f"Using {os.environ[FUSEBUILD_INVOCATION_DIR]} as invocation dir.")
+    invocation_dir = Path(os.environ[FUSEBUILD_INVOCATION_DIR])
+    logger.info(f"Using {invocation_dir} as invocation dir.")
 
     categories = frozenset(arg.category.split(","))
 
@@ -310,7 +334,9 @@ def main_inner(args: list[str]) -> int:
     max_running = arg.parallel
     if max_running <= 0:
         max_running = cpu_count()
-    executer = ActionExecuterImpl(max_running=max_running)
+    executer = ActionExecuterImpl(
+        max_running=max_running, invocation_dir=invocation_dir
+    )
     for ti in arg.target:
         t: Path = ti.absolute()
         logger.debug(f"Processing {ti} at {os.getcwd()=}: {t=}")

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -515,9 +515,11 @@ class ActionExecuterImpl(ActionExecuter):
                     await self.action_done(d)
         finally:
             logger.info("Closing unix socket")
+            for client in self.open_connections:
+                client.close()
             server.close()
             await server.wait_closed()
-            logger.info("Unix socker closed")
+            logger.info("Unix socket closed")
             s_path.unlink(missing_ok=True)
 
             if self.connection_reader_tasks:

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -377,7 +377,12 @@ class ActionExecuterImpl(ActionExecuter):
             logger.info(f"Closing connection from {peername}")
             self.open_connections.discard(writer)
             writer.close()
-            await writer.wait_closed()
+            try:
+                await writer.wait_closed()
+            except ConnectionResetError:
+                pass
+            except BrokenPipeError:
+                pass
 
     def remove_connection_reader_task(self, task: asyncio.Task[Any]) -> None:
         logger.debug("Removing connection")

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -517,7 +517,7 @@ class ActionExecuterImpl(ActionExecuter):
             logger.info("Closing unix socket")
             server.close()
             await server.wait_closed()
-
+            logger.info("Unix socker closed")
             s_path.unlink(missing_ok=True)
 
             if self.connection_reader_tasks:
@@ -528,12 +528,14 @@ class ActionExecuterImpl(ActionExecuter):
                 for task in tasks:
                     task.cancel()
 
+                logger.info("Gather {len(tasks)} connection reader tasks")
                 await asyncio.gather(*tasks, return_exceptions=True)
 
             if self.open_connections:
                 logger.warning(
                     f"{len(self.open_connections)} connections were not cleaned up properly."
                 )
+            logger.info("Done closing connections")
 
 
 @dataclass(frozen=True)

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -83,9 +83,8 @@ def print_failure(label: ActionLabel, seen: set[ActionLabel]) -> None:
                 return
             if status.status != StatusEnum.DONE:
                 print(
-                    f"Some other is building {label} (pid={status.running_pid}) such that failure can't be printed"
+                    f"Some other is building {label} (pid={status.running_pid}) such that failure can't be printed reliable"
                 )
-                return
             subbuild_failed_path = subbuild_failed_file(label)
             if subbuild_failed_path.exists():
                 seen2 = seen.union({label})

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -148,6 +148,8 @@ class ActionExecuterImpl(ActionExecuter):
         self.max_running = max_running
         self.invoker = DummyInvoker()
         self.invocation_dir = invocation_dir
+        self.open_connections: list[asyncio.StreamWriter] = []
+        self.connection_reader_tasks: set[asyncio.Task[Any]] = set()
 
     def schedule_action(self, action: BuildAction) -> None:
         self.need_resort = True
@@ -240,14 +242,39 @@ class ActionExecuterImpl(ActionExecuter):
             if action.needed:
                 self.failures.append(action)
 
+    async def _read_from_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        peername = writer.get_extra_info("peername")
+        logger.info(f"Start reading from {peername}")
+        try:
+            while not reader.at_eof():
+                line = await reader.readline()
+                if not line:
+                    break
+                logger.info(f"Received from {peername}: {line.decode().strip()}")
+        except asyncio.CancelledError:
+            logger.info(f"Reader task for {peername} cancelled.")
+            raise
+        except Exception as e:
+            logger.error(f"Error reading from {peername}: {e}")
+        finally:
+            logger.info(f"Closing connection from {peername}")
+            if writer in self.open_connections:
+                self.open_connections.remove(writer)
+            writer.close()
+            await writer.wait_closed()
+
     async def handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
-        # For now, just log and close the connection
         peername = writer.get_extra_info("peername")
         logger.info(f"Received connection from {peername}")
-        writer.close()
-        await writer.wait_closed()
+        self.open_connections.append(writer)
+
+        task = asyncio.create_task(self._read_from_connection(reader, writer))
+        self.connection_reader_tasks.add(task)
+        task.add_done_callback(self.connection_reader_tasks.discard)
 
     async def run(self) -> int:
         socket_path = self.invocation_dir / "fusebuild.sock"
@@ -292,6 +319,21 @@ class ActionExecuterImpl(ActionExecuter):
             server.close()
             await server.wait_closed()
             socket_path.unlink(missing_ok=True)
+
+            if self.connection_reader_tasks:
+                logger.info(
+                    f"Closing {len(self.connection_reader_tasks)} client connections"
+                )
+                tasks = list(self.connection_reader_tasks)
+                for task in tasks:
+                    task.cancel()
+
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+            if self.open_connections:
+                logger.warning(
+                    f"{len(self.open_connections)} connections were not cleaned up properly."
+                )
 
 
 @dataclass(frozen=True)

--- a/fusebuild/core/main.py
+++ b/fusebuild/core/main.py
@@ -440,12 +440,27 @@ class ActionExecuterImpl(ActionExecuter):
         for action in self.pending:
             await self.schedule_action(action)
         self.pending = []
+        next_print = time.monotonic()
         try:
             while True:
                 if len(self.failures) > 0:
                     failure = self.failures[0]
                     print_failure(failure.label, set([]))
                     return 1
+                now = time.monotonic()
+                if now > next_print:
+                    next_print += 1
+                    for a in self.waiting:
+                        print(f"{a} waiting")
+                    for a in self.runable:
+                        print(f"{a} runable")
+                    for a in self.blocked:
+                        print(f"{a} blocked")
+                    for a in self.blocked_runable:
+                        print(f"{a} blocked runable")
+                    for _, action in self.started.values():
+                        if action.status == BuildActionStatus.RUNNING:
+                            print(f"{action.label} running")
 
                 logger.debug(
                     f"{len(self.waiting)=} {len(self.runable)=} {len(self.started)=} {len(self.blocked)=}  {len(self.blocked_runable)=}"
@@ -485,7 +500,7 @@ class ActionExecuterImpl(ActionExecuter):
 
                 done, pending = await asyncio.wait(
                     [t for t in self.started.keys()] + [wakeup_task],
-                    timeout=10,
+                    timeout=1,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if len(done) == 0:

--- a/fusebuild/core/runtarget.py
+++ b/fusebuild/core/runtarget.py
@@ -19,12 +19,15 @@ def _runtarget(buildfile: Path, target: str, invoker: ActionInvoker) -> int | No
     logger.debug(f"Runtarget {buildfile=} {target=} {invoker=}")
     assert buildfile.is_file()
     executer = get_action_executer(buildfile.parent, target, invoker)
-    if executer is None:
-        return -1
-    return_code = executer.run_if_needed(
-        invoker, f"building {[str(a) for a in invoker.runtarget_args()]}"
-    )
-    return return_code
+    match executer:
+        case int(x):
+            # Some error code
+            return executer
+        case BasicExecuter:
+            return_code = executer.run_if_needed(
+                invoker, f"building {[str(a) for a in invoker.runtarget_args()]}"
+            )
+            return return_code
 
 
 if __name__ == "__main__":

--- a/fusebuild/core/utils.py
+++ b/fusebuild/core/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote, unquote
 
 import psutil
 
@@ -86,3 +87,19 @@ def run_action(directory: Path, target: str, invoker: ActionInvoker) -> int:
             kill_subprocess(process)
         raise
     return res
+
+
+from urllib.parse import quote, unquote
+
+
+def escape_whitespace(text: str) -> str:
+    """Replaces all space and non-ASCII characters with %hexcode as in URLs"""
+    return quote(
+        text,
+        safe="!\"#$&'()*+,-./:;<=>?@[\\]^_`{|}~ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+    )
+
+
+def unescape_whitespace(text: str) -> str:
+    """Reverses the above"""
+    return unquote(text)

--- a/test/core/FUSEBUILD.py
+++ b/test/core/FUSEBUILD.py
@@ -1,0 +1,17 @@
+from fusebuild import BwrapSandbox, NoSandbox, get_action, shell_action
+from fusebuild.python import mypy_actions, pyc_actions, pyc_mappings
+
+pyc_actions()
+mypy_actions()
+
+shell_action(
+    name="test_utils",
+    cmd="\n".join(
+        [
+            ". $OUTPUT_DIR/../../../venv/bin/activate",
+            "python -B test_utils.py",
+        ]
+    ),
+    category="test",
+    mappings=pyc_mappings(),
+)

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -1,0 +1,32 @@
+import unittest
+
+from fusebuild.core.utils import escape_whitespace as escape
+from fusebuild.core.utils import unescape_whitespace as unescape
+
+
+class TestWhitespaceEncoding(unittest.TestCase):
+
+    def test_round_trip_simple(self) -> None:
+        original = "hello world"
+        self.assertEqual(unescape(escape(original)), original)
+
+    def test_round_trip_all_whitespace(self) -> None:
+        original = " \t\n\r\v\f"
+        self.assertEqual(unescape(escape(original)), original)
+
+    def test_round_trip_mixed_content(self) -> None:
+        original = "Line 1\nLine 2\tEnd"
+        self.assertEqual(unescape(escape(original)), original)
+
+    def test_empty_string(self) -> None:
+        original = ""
+        self.assertEqual(unescape(escape(original)), original)
+
+    def test_literal_percent_sequences(self) -> None:
+        # Ensure already-percent-like sequences survive round-trip
+        original = "100% safe %20 text"
+        self.assertEqual(unescape(escape(original)), original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_circular.py
+++ b/test/test_circular.py
@@ -39,7 +39,8 @@ class TestCircular(TestCase):
                 "fusebuild",
                 "circular",
                 str(self.workdir / "A"),
-            ]
+            ],
+            timeout=60,
         )
         self.assertEqual(ret.returncode, 1)
 
@@ -78,7 +79,8 @@ shell_action(
                 "fusebuild",
                 "circular",
                 str(self.workdir / "A"),
-            ]
+            ],
+            timeout=60,
         )
         self.assertEqual(ret.returncode, 0)
 
@@ -95,7 +97,8 @@ shell_action(
                 "fusebuild",
                 "circular",
                 str(self.workdir / "A"),
-            ]
+            ],
+            timeout=60,
         )
         self.assertEqual(ret.returncode, 1)
 
@@ -107,7 +110,8 @@ shell_action(
                 "fusebuild",
                 "circular",
                 str(self.workdir / "D"),
-            ]
+            ],
+            timeout=60,
         )
         self.assertEqual(ret.returncode, 1)
 
@@ -151,7 +155,8 @@ get_action("../subA", "A")
                 "fusebuild",
                 "build",
                 str(self.workdir),
-            ]
+            ],
+            timeout=60,
         )
         self.assertEqual(ret.returncode, 1)
 

--- a/test/test_circular.py
+++ b/test/test_circular.py
@@ -42,7 +42,7 @@ class TestCircular(TestCase):
             ],
             timeout=60,
         )
-        self.assertEqual(ret.returncode, 1)
+        self.assertEqual(ret.returncode, 4)
 
         # Now testing that breaking the circular dependency will fix the build
         (self.workdir / "FUSEBUILD.py").write_text(
@@ -100,7 +100,7 @@ shell_action(
             ],
             timeout=60,
         )
-        self.assertEqual(ret.returncode, 1)
+        self.assertEqual(ret.returncode, 4)
 
     def test_build_circular_from_out_of_circle(self) -> None:
         ret = subprocess.run(
@@ -113,7 +113,7 @@ shell_action(
             ],
             timeout=60,
         )
-        self.assertEqual(ret.returncode, 1)
+        self.assertEqual(ret.returncode, 4)
 
     def test_circular_fusebuild_files(self) -> None:
         # Avoid original error
@@ -158,7 +158,7 @@ get_action("../subA", "A")
             ],
             timeout=120,
         )
-        self.assertEqual(ret.returncode, 1)
+        self.assertEqual(ret.returncode, 4)
 
 
 if __name__ == "__main__":

--- a/test/test_circular.py
+++ b/test/test_circular.py
@@ -156,7 +156,7 @@ get_action("../subA", "A")
                 "build",
                 str(self.workdir),
             ],
-            timeout=60,
+            timeout=120,
         )
         self.assertEqual(ret.returncode, 1)
 

--- a/test/test_example1.py
+++ b/test/test_example1.py
@@ -145,7 +145,7 @@ class TestExample1(TestCase):
                 str(self.workdir) + "/fail",
             ]
         )
-        self.assertEqual(ret.returncode, 1)
+        self.assertEqual(ret.returncode, 3)
 
     def test_handle_change_to_input_under_build(self) -> None:
         with create_tcp_server() as sock:

--- a/test/test_example2.py
+++ b/test/test_example2.py
@@ -111,7 +111,7 @@ shell_action(name="someaction",
         )
 
         ret = run(build_cmd)
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, 3)
 
         # Test that failed FUSEBUILD.py gives a failed build
         with (self.workdir / "FUSEBUILD.py").open("w") as f:
@@ -138,7 +138,7 @@ shell_action(name="someaction",
         )
 
         ret = run(build_cmd)
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of recursively spawning build actions as needed, make the main process listen for what dependencies are found dynamically. This is done to better control shutdown, potentially make nicer output and potentially to speed up building by centralizing dependency checking.